### PR TITLE
Adds support for a list of processes

### DIFF
--- a/node-wmic.js
+++ b/node-wmic.js
@@ -10,7 +10,8 @@ const cmd = {
     'bios': [['bios', 'get', '/VALUE'], 31],
     'diskdrive': [['diskdrive', 'get', '/VALUE'], 51],
     'os': [['os', 'get', '/VALUE'], 64],
-    'memorychip': [['memorychip', 'get', '/VALUE'], 36]
+    'memorychip': [['memorychip', 'get', '/VALUE'], 36],
+    'process': [['process', 'get', '/VALUE'], 40]
 };
 
 function wmicFormat(stdout, size) {
@@ -43,7 +44,7 @@ let func = [];
 for (let key in cmd) {
     func[key] = () => {
         return new Promise((resolve, reject) => {
-            execFile(path.join(process.env.SystemRoot,'System32','wbem', 'WMIC.exe'), cmd[key][0], {encoding: 'GB2312'},(err, stdout, stderr) => {
+            execFile(path.join(process.env.SystemRoot,'System32','wbem', 'WMIC.exe'), cmd[key][0], {encoding: 'GB2312', maxBuffer: 1024 * 500},(err, stdout, stderr) => {
                 if(err) {
                     reject(stderr);
                 } else {


### PR DESCRIPTION
Add's support to fetch all processes. A maxBuffer size had to be passed to the child_process, 500KB, as the default 200KB was not enough and was causing a buffer overflow when fetching a list of processes.

Documentation for child_process can be found [here.](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)

* Should probably include some sort of support in the future to specify the buffer size.

      wmic.process().then(result => {
            console.log(result);
        });